### PR TITLE
Your BLEConnect doesn't work / implement the standard on Android devices.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.people_who_try_to_use_this


### PR DESCRIPTION
Hi,
I opened a pull request (with no further content) because you don't accept issues.
In Android, you do not advertise a Client Characteristic Configuration Descriptor. This means, that one cannot subscribe to notifications of your BLE service, yet this is what you have to do for this to work.
I still haven't gotten it to work on my ESP, but [some people apparently have _modifying the library_ on their end device, so that it accepts your non-standard way of doing things](https://github.com/jstiefel/esp32_komoot_ble/issues/3).
This apparently also breaks any cross-compability you might have with iOS and Android devices.
This involves a lot of unnecessary headache for people who try to use this API, I still haven't figured out how to modify my client. Please fix it in your app, or at least show some kind of response. Thanks!